### PR TITLE
fix: temporary hold nunjucks version to ~3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "nunjucks"
   ],
   "dependencies": {
-    "nunjucks": "^3.0.1"
+    "nunjucks": "~3.0.1"
   },
   "devDependencies": {
     "autod": "^3.0.1",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
nunjucks 3.1.0 break, `cache` is gone.
- https://travis-ci.org/eggjs/egg-view-nunjucks/jobs/344959780
- https://github.com/mozilla/nunjucks/compare/v3.0.1...v3.1.0