### PR TITLE
fix: default config

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -8,7 +8,7 @@ module.exports = app => {
   const viewPaths = app.config.view.root;
   coreLogger.info('[egg-view-nunjucks] loading templates from %j', viewPaths);
 
-  const config = app.config.nunjucks;
+  const config = app.config.nunjucks || {};
   config.noCache = !config.cache;
   delete config.cache;
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

fix TypeError when forget to set `config.nunjucks = {};`

TypeError: Cannot read property 'cache' of undefined
    at module.exports.app (/Users/admin/Desktop/project/****-server/packages/egg-****/node_modules/egg-view-nunjucks/lib/engine.js:12:28)
    at Application.get nunjucks [as nunjucks] (/Users/admin/Desktop/project/****-server/packages/egg-****/node_modules/egg-view-nunjucks/app/extend/application.js:15:24)
    at new NunjucksView (/Users/admin/Desktop/project/****-server/packages/egg-****/node_modules/egg-view-nunjucks/lib/view.js:7:36)
    at ContextView.[contextView#getViewEngine] (/Users/admin/Desktop/project/****-server/node_modules/egg-view/lib/context_view.js:91:20)
    at ContextView.[contextView#renderString] (/Users/admin/Desktop/project/****-server/node_modules/egg-view/lib/context_view.js:81:39)
    at ContextView.renderString (/Users/admin/Desktop/project/****-server/node_modules/egg-view/lib/context_view.js:44:31)
    at Object.renderString (/Users/admin/Desktop/project/****-server/node_modules/egg-view/app/extend/context.js:32:22)
    at Function.res (/Users/admin/Desktop/project/****-server/packages/egg-****/lib/helpers/Response.js:29:30)
    at Promise.resolve.then.then.then.then (/Users/admin/Desktop/project/****-server/packages/egg-****/lib/index.js:26:31)
    at process._tickCallback (internal/process/next_tick.js:68:7)
##### Description of change
<!-- Provide a description of the change below this comment. -->



