### PR TITLE
feat: renderString support opts

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,42 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [6, 8, 9]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+    - name: Checkout Git Source
+      uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install Dependencies
+      run: npm i -g npminstall && npminstall
+
+    - name: Continuous Integration
+      run: npm run ci
+
+    - name: Code Coverage
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -59,7 +59,10 @@ class TestController extends Controller {
     const ctx = this.ctx;
     // ctx.body = await ctx.renderString('{{ name }}', { name: 'local' });
     // not need to assign `ctx.render` to `ctx.body`
-    await ctx.render('test.nj', { name: 'view test' });
+    // https://github.com/mozilla/nunjucks/blob/6f3e4a36a71cfd59ddc8c1fc5dcd77b8c24d83f3/nunjucks/src/environment.js#L318
+    await ctx.render('test.nj', { name: 'view test' }, {
+      path: '***'
+    });
   }
 }
 ```
@@ -80,7 +83,9 @@ exports.hello = name => `hi, ${name}`;
 class TestController extends Controller {
   async list() {
     const ctx = this.ctx;
-    ctx.body = await ctx.renderString('{{ name | hello }}', { name: 'egg' });
+    ctx.body = await ctx.renderString('{{ name | hello }}', { name: 'egg' }, {
+      path: '***'
+    });
   };
 }
 ```

--- a/lib/view.js
+++ b/lib/view.js
@@ -17,10 +17,10 @@ class NunjucksView {
     });
   }
 
-  renderString(tpl, locals) {
+  renderString(tpl, locals, opts) {
     locals.helper = this.viewHelper;
     return new Promise((resolve, reject) => {
-      this.app.nunjucks.renderString(tpl, locals, (err, result) => {
+      this.app.nunjucks.renderString(tpl, locals, opts, (err, result) => {
         if (err) return reject(err);
         resolve(result);
       });

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "nunjucks"
   ],
   "dependencies": {
-    "nunjucks": "^3.1.2"
+    "nunjucks": "^3.2.2"
   },
   "devDependencies": {
     "autod": "^3.0.1",

--- a/test/fixtures/example/app/router.js
+++ b/test/fixtures/example/app/router.js
@@ -1,5 +1,6 @@
 'use strict';
-
+const path = require('path');
+const fs = require('fs');
 module.exports = app => {
   app.get('/', function* () {
     yield this.render('home.tpl', { user: 'egg' });
@@ -7,6 +8,14 @@ module.exports = app => {
 
   app.get('/string', function* () {
     this.body = yield this.renderString('hi, {{ user }}', { user: 'egg' });
+  });
+
+  app.get('/string_options', function* () {
+    this.body = yield this.renderString(
+      fs.readFileSync(path.resolve(__dirname, './view/layout.tpl')).toString(),
+      { user: 'egg' },
+      { path: path.resolve(__dirname, './view/layout.tpl') }
+    );
   });
 
   app.get('/inject', function* () {
@@ -36,6 +45,7 @@ module.exports = app => {
     this.locals = { b: 'ctx' };
     this.body = yield this.renderString('{{ a }}, {{ b }}, {{ c }}', { c: 'locals' });
   });
+
 
   app.get('/error_string', function* () {
     try {

--- a/test/fixtures/example/app/view/layout.tpl
+++ b/test/fixtures/example/app/view/layout.tpl
@@ -1,0 +1,6 @@
+{% extends "./layout/index.tpl" %}
+{% block cssContents %}
+<link rel="stylesheet" href="//{{ctx.cdnHost}}/ife/libs/next/theme-11/next.min.css">
+<link rel="stylesheet" href="//{{ctx.cdnHost}}/customize/index.css">
+{% endblock %}
+

--- a/test/fixtures/example/app/view/layout/index.tpl
+++ b/test/fixtures/example/app/view/layout/index.tpl
@@ -1,0 +1,7 @@
+<html>
+<head>
+  {% block cssContents %}
+  <link rel="stylesheet" href="{{cssFile}}">
+  {% endblock %}
+</head>
+<div>{{ user }}<div>

--- a/test/view/view.test.js
+++ b/test/view/view.test.js
@@ -29,6 +29,13 @@ describe('test/view/view.test.js', () => {
       .expect(/hi, egg/);
   });
 
+  it('should render string with options path', function* () {
+    yield app.httpRequest()
+      .get('/string_options')
+      .expect(200)
+      .expect(/<div>egg<div>/);
+  });
+
   it('should render template', function* () {
     yield app.httpRequest()
       .get('/')


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
nunjucks 在 3.2.x 以上的版本支持了 renderString 的时候传入第三个配置参数，其中 path 为支持渲染 string 中的一些类似 layout 等需要从其他地方读取文件地址的 basePath .
参考：https://github.com/mozilla/nunjucks/blob/6f3e4a36a71cfd59ddc8c1fc5dcd77b8c24d83f3/nunjucks/src/environment.js#L318

但现在 egg-view-nunjucks 在 renderString 的时候漏了第三个参数。
```js
  renderString(tpl, locals, opts) {
    locals.helper = this.viewHelper;
    return new Promise((resolve, reject) => {
      this.app.nunjucks.renderString(tpl, locals, opts, (err, result) => {
        if (err) return reject(err);
        resolve(result);
      });
    });
  }
```
